### PR TITLE
VS2019対応 fix #5

### DIFF
--- a/LibDbHelper.Test/DbHelperTest.cs
+++ b/LibDbHelper.Test/DbHelperTest.cs
@@ -1,106 +1,160 @@
 ﻿using LibDbHelper.Attributes;
 using LibDbHelper.Test.Items;
 using LibDbHelper.Test.Stubs;
+using System;
+using System.Collections.Generic;
 using System.Data.Common;
+using System.Threading.Tasks;
+using Xunit;
 using Xunit.Abstractions;
 
-namespace LibDbHelper.Test;
-
-public class DbHelperTest(ITestOutputHelper testOutputHelper)
+namespace LibDbHelper.Test
 {
-    private readonly DbHelper helper_ = new StubDbHelper(testOutputHelper);
-
-    [Fact]
-    public async Task QueryAsync_ColumnName属性不使用()
+    public class DbHelperTest
     {
-        // Arange
-        var table = new Table(
-            ["col_a", "col_b"],
-            [
-                [0, 1, 2],
-                ["x", "y", "z"],
-            ]
-        );
-        ((StubDbHelper)helper_).SetTable(table);
-        var sql = "SELECT * FROM T";
-        var parameters = new List<DbParameter> { helper_.GetParameter("n", 1) };
+        private readonly DbHelper helper_;
 
-        // Act
-        var actual = await helper_.QueryAsync(
-            sql, parameters,
-            r => new Entity(r.GetInt("col_a"), r.GetString("col_b"))
-        );
+        public DbHelperTest(ITestOutputHelper testOutputHelper)
+        {
+            helper_ = new StubDbHelper(testOutputHelper);
+        }
 
-        //Assert
-        Assert.Equal([new(0, "x"), new(1, "y"), new(2, "z")], actual);
-    }
+        [Fact]
+        public async Task QueryAsync_ColumnName属性不使用()
+        {
+            // Arange
+            var table = new Table(
+                new List<string> { "col_a", "col_b" },
+                new List<IEnumerable<object>>
+                {
+                    new List<object>{ 0, 1, 2 },
+                    new List<object>{ "x", "y", "z" },
+                }
+            );
+            ((StubDbHelper)helper_).SetTable(table);
+            var sql = "SELECT * FROM T";
+            var parameters = new List<DbParameter> { helper_.GetParameter("n", 1) };
 
-    [Fact]
-    public async Task QueryAsync_ColumnName属性使用()
-    {
-        // Arange
-        var table = new Table(
-            ["col_a", "col_b"],
-            [
-                [0, 1, 2],
-                ["x", "y", "z"],
-            ]
-        );
-        ((StubDbHelper)helper_).SetTable(table);
-        var sql = "SELECT * FROM T";
-        var parameters = new List<DbParameter> { helper_.GetParameter("n", 1) };
+            // Act
+            var actual = await helper_.QueryAsync(
+                sql, parameters,
+                r => new Entity(r.GetInt("col_a"), r.GetString("col_b"))
+            );
 
-        // Act
-        var actual = await helper_.QueryAsync<Entity>(sql, parameters);
-
-        //Assert
-        Assert.Equal([new(0, "x"), new(1, "y"), new(2, "z")], actual);
-    }
-
-    [Fact]
-    public async Task ExecuteAsync()
-    {
-        // Arange
-        var sql = "UPDATE T SET col_a = 1 WHERE col_b = :b";
-        var parameters = new List<DbParameter> { helper_.GetParameter("b", 1) };
-
-        // Act
-        await helper_.ExecuteAsync(sql, parameters);
-
-        //Assert
-    }
-
-    [Fact]
-    public async Task BulkInsertAsync()
-    {
-        // Arange
-        var table = "Schema.Table";
-        List<string> columns = ["col_a", "col_b", "col_c"];
-        List<string> values = [":a", ":b", "c"];
-        List<Entity> entities = [new(0, "x"), new(1, "y"), new(2, "z")];
-
-        // Act
-        await helper_.BulkInsertAsync(
-            table, columns, values, entities,
-            (name, x) => name switch
+            //Assert
+            var expected = new List<Entity>
             {
-                "a" => x.A,
-                "b" => x.B,
-                _ => throw new ArgumentException($"登録されていないパラメーター名です。 name:{name}", nameof(name))
-            }
-        );
+                new Entity(0, "x"),
+                new Entity(1, "y"),
+                new Entity(2, "z"),
+            }.AsReadOnly();
+            Assert.Equal(expected, actual);
+        }
 
-        //Assert
+        [Fact]
+        public async Task QueryAsync_ColumnName属性使用()
+        {
+            // Arange
+            var table = new Table(
+                new List<string> { "col_a", "col_b" },
+                new List<IEnumerable<object>>
+                {
+                    new List<object>{ 0, 1, 2 },
+                    new List<object>{ "x", "y", "z" },
+                }
+            );
+            ((StubDbHelper)helper_).SetTable(table);
+            var sql = "SELECT * FROM T";
+            var parameters = new List<DbParameter> { helper_.GetParameter("n", 1) };
+
+            // Act
+            var actual = await helper_.QueryAsync<Entity>(sql, parameters);
+
+            //Assert
+            var expected = new List<Entity>
+            {
+                new Entity(0, "x"),
+                new Entity(1, "y"),
+                new Entity(2, "z"),
+            }.AsReadOnly();
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public async Task ExecuteAsync()
+        {
+            // Arange
+            var sql = "UPDATE T SET col_a = 1 WHERE col_b = :b";
+            var parameters = new List<DbParameter> { helper_.GetParameter("b", 1) };
+
+            // Act
+            await helper_.ExecuteAsync(sql, parameters);
+
+            //Assert
+        }
+
+        [Fact]
+        public async Task BulkInsertAsync()
+        {
+            // Arange
+            var table = "Schema.Table";
+            var columns = new List<string> { "col_a", "col_b", "col_c" };
+            var values = new List<string> { ":a", ":b", "c" };
+            var entities = new List<Entity>
+            {
+                new Entity(0, "x"),
+                new Entity(1, "y"),
+                new Entity(2, "z"),
+            };
+
+            // Act
+            await helper_.BulkInsertAsync(
+                table, columns, values, entities,
+                (name, x) =>
+                {
+                    switch (name)
+                    {
+                        case "a":
+                            return x.A;
+
+                        case "b":
+                            return x.B;
+
+                        default:
+                            throw new ArgumentException($"登録されていないパラメーター名です。 name:{name}", nameof(name));
+                    }
+                }
+            );
+
+            //Assert
+        }
+
+        private class Entity : IEquatable<Entity>
+        {
+            [ColumnName("col_a")]
+            public int A { get; set; }
+
+            [ColumnName("col_b")]
+            public string B { get; set; }
+
+            public Entity(int a, string b)
+            {
+                A = a;
+                B = b;
+            }
+
+            public bool Equals(Entity other)
+            {
+                return other != null &&
+                    A == other.A &&
+                    B == other.B;
+            }
+        }
     }
 
-    private record Entity(
-        [property: ColumnName("col_a")] int A,
-        [property: ColumnName("col_b")] string B
-    );
+    // Arange
+
+    // Act
+
+    //Assert
 }
-
-// Arange
-
-// Act
-
-//Assert

--- a/LibDbHelper.Test/IsExternalInit.cs
+++ b/LibDbHelper.Test/IsExternalInit.cs
@@ -1,3 +1,4 @@
-﻿namespace System.Runtime.CompilerServices;
-
-public static class IsExternalInit { }
+﻿namespace System.Runtime.CompilerServices
+{
+    public static class IsExternalInit { }
+}

--- a/LibDbHelper.Test/Items/Column.cs
+++ b/LibDbHelper.Test/Items/Column.cs
@@ -1,8 +1,19 @@
-﻿namespace LibDbHelper.Test.Items;
+﻿using System.Collections.Generic;
+using System.Linq;
 
-public class Column(string name, IEnumerable<object> values)
+namespace LibDbHelper.Test.Items
 {
-    public string Name { get; set; } = name;
-    public List<object> Values { get; set; } = [.. values];
-    public object this[int index] => Values[index];
+    public class Column
+    {
+        public string Name { get; set; }
+        public List<object> Values { get; set; }
+
+        public object this[int index] => Values[index];
+
+        public Column(string name, IEnumerable<object> values)
+        {
+            Name = name;
+            Values = values.ToList();
+        }
+    }
 }

--- a/LibDbHelper.Test/Items/Table.cs
+++ b/LibDbHelper.Test/Items/Table.cs
@@ -1,9 +1,20 @@
-﻿namespace LibDbHelper.Test.Items;
+﻿using System.Collections.Generic;
+using System.Linq;
 
-public class Table(IEnumerable<string> columnNames, IEnumerable<IEnumerable<object>> columnValues)
+namespace LibDbHelper.Test.Items
 {
-    public List<string> ColumnNames { get; } = [.. columnNames];
-    public List<Column> Columns { get; } = [.. columnNames.Select((x, i) => new Column(x, columnValues.ElementAt(i)))];
-    public Column this[int index] => Columns[index];
-    public Column this[string name] => Columns[ColumnNames.IndexOf(name)];
+    public class Table
+    {
+        public List<string> ColumnNames { get; }
+        public List<Column> Columns { get; }
+
+        public Column this[int index] => Columns[index];
+        public Column this[string name] => Columns[ColumnNames.IndexOf(name)];
+
+        public Table(IEnumerable<string> columnNames, IEnumerable<IEnumerable<object>> columnValues)
+        {
+            ColumnNames = columnNames.ToList();
+            Columns = columnNames.Select((x, i) => new Column(x, columnValues.ElementAt(i))).ToList();
+        }
+    }
 }

--- a/LibDbHelper.Test/LibDbHelper.Test.csproj
+++ b/LibDbHelper.Test/LibDbHelper.Test.csproj
@@ -2,8 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <LangVersion>latest</LangVersion>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
@@ -17,10 +15,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\LibDbHelper\LibDbHelper.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Using Include="Xunit" />
   </ItemGroup>
 
 </Project>

--- a/LibDbHelper.Test/Stubs/StubDbCommand.cs
+++ b/LibDbHelper.Test/Stubs/StubDbCommand.cs
@@ -1,45 +1,53 @@
-﻿using System.Data;
+﻿using LibDbHelper.Test.Items;
+using System.Data;
 using System.Data.Common;
-using LibDbHelper.Test.Items;
 
-namespace LibDbHelper.Test.Stubs;
-
-public class StubDbCommand(Table table) : DbCommand
+namespace LibDbHelper.Test.Stubs
 {
-    public override string CommandText { get; set; }
-    public override int CommandTimeout { get; set; }
-    public override CommandType CommandType { get; set; }
-    public override bool DesignTimeVisible { get; set; }
-    public override UpdateRowSource UpdatedRowSource { get; set; }
-    protected override DbConnection DbConnection { get; set; }
-    protected override DbParameterCollection DbParameterCollection { get; } = new StubDbParameterCollection();
-    protected override DbTransaction DbTransaction { get; set; }
-
-    public override void Cancel()
+    public class StubDbCommand : DbCommand
     {
-    }
+        public override string CommandText { get; set; }
+        public override int CommandTimeout { get; set; }
+        public override CommandType CommandType { get; set; }
+        public override bool DesignTimeVisible { get; set; }
+        public override UpdateRowSource UpdatedRowSource { get; set; }
+        protected override DbConnection DbConnection { get; set; }
+        protected override DbParameterCollection DbParameterCollection { get; } = new StubDbParameterCollection();
+        protected override DbTransaction DbTransaction { get; set; }
 
-    public override int ExecuteNonQuery()
-    {
-        return 1;
-    }
+        private readonly Table table_;
 
-    public override object ExecuteScalar()
-    {
-        return new object();
-    }
+        public StubDbCommand(Table table)
+        {
+            table_ = table;
+        }
 
-    public override void Prepare()
-    {
-    }
+        public override void Cancel()
+        {
+        }
 
-    protected override DbParameter CreateDbParameter()
-    {
-        return new StubDbParameter();
-    }
+        public override int ExecuteNonQuery()
+        {
+            return 1;
+        }
 
-    protected override DbDataReader ExecuteDbDataReader(CommandBehavior behavior)
-    {
-        return new StubDbDataReader(table);
+        public override object ExecuteScalar()
+        {
+            return new object();
+        }
+
+        public override void Prepare()
+        {
+        }
+
+        protected override DbParameter CreateDbParameter()
+        {
+            return new StubDbParameter();
+        }
+
+        protected override DbDataReader ExecuteDbDataReader(CommandBehavior behavior)
+        {
+            return new StubDbDataReader(table_);
+        }
     }
 }

--- a/LibDbHelper.Test/Stubs/StubDbConnection.cs
+++ b/LibDbHelper.Test/Stubs/StubDbConnection.cs
@@ -1,36 +1,44 @@
-﻿using System.Data;
+﻿using LibDbHelper.Test.Items;
+using System.Data;
 using System.Data.Common;
-using LibDbHelper.Test.Items;
 
-namespace LibDbHelper.Test.Stubs;
-
-public class StubDbConnection(Table table) : DbConnection
+namespace LibDbHelper.Test.Stubs
 {
-    public override string ConnectionString { get; set; }
-    public override string Database { get; }
-    public override string DataSource { get; }
-    public override string ServerVersion { get; }
-    public override ConnectionState State { get; }
-
-    public override void ChangeDatabase(string databaseName)
+    public class StubDbConnection : DbConnection
     {
-    }
+        public override string ConnectionString { get; set; }
+        public override string Database { get; }
+        public override string DataSource { get; }
+        public override string ServerVersion { get; }
+        public override ConnectionState State { get; }
 
-    public override void Open()
-    {
-    }
+        private readonly Table table_;
 
-    public override void Close()
-    {
-    }
+        public StubDbConnection(Table table)
+        {
+            table_ = table;
+        }
 
-    protected override DbTransaction BeginDbTransaction(IsolationLevel isolationLevel)
-    {
-        return new StubDbTransaction(this, isolationLevel);
-    }
+        public override void ChangeDatabase(string databaseName)
+        {
+        }
 
-    protected override DbCommand CreateDbCommand()
-    {
-        return new StubDbCommand(table);
+        public override void Open()
+        {
+        }
+
+        public override void Close()
+        {
+        }
+
+        protected override DbTransaction BeginDbTransaction(IsolationLevel isolationLevel)
+        {
+            return new StubDbTransaction(this, isolationLevel);
+        }
+
+        protected override DbCommand CreateDbCommand()
+        {
+            return new StubDbCommand(table_);
+        }
     }
 }

--- a/LibDbHelper.Test/Stubs/StubDbDataReader.cs
+++ b/LibDbHelper.Test/Stubs/StubDbDataReader.cs
@@ -1,142 +1,151 @@
-﻿using System.Collections;
+﻿using LibDbHelper.Test.Items;
+using System;
+using System.Collections;
 using System.Data.Common;
-using LibDbHelper.Test.Items;
+using System.Linq;
 
-namespace LibDbHelper.Test.Stubs;
-
-public class StubDbDataReader(Table table) : DbDataReader
+namespace LibDbHelper.Test.Stubs
 {
-    public override object this[int ordinal] => table[ordinal][rowNum_];
-    public override object this[string name] => table[name][rowNum_];
-
-    public override int Depth { get; }
-    public override int FieldCount { get; }
-    public override bool HasRows { get; }
-    public override bool IsClosed { get; }
-    public override int RecordsAffected { get; }
-
-    private int rowNum_ = -1;
-
-    public override bool GetBoolean(int ordinal)
+    public class StubDbDataReader : DbDataReader
     {
-        return (int)table[ordinal][rowNum_] != 0;
-    }
+        public override object this[int ordinal] => table_[ordinal][rowNum_];
+        public override object this[string name] => table_[name][rowNum_];
 
-    public override byte GetByte(int ordinal)
-    {
-        return (byte)table[ordinal][rowNum_];
-    }
+        public override int Depth { get; }
+        public override int FieldCount { get; }
+        public override bool HasRows { get; }
+        public override bool IsClosed { get; }
+        public override int RecordsAffected { get; }
 
-    public override long GetBytes(int ordinal, long dataOffset, byte[] buffer, int bufferOffset, int length)
-    {
-        throw new NotImplementedException();
-    }
+        private readonly Table table_;
+        private int rowNum_ = -1;
 
-    public override char GetChar(int ordinal)
-    {
-        return (char)table[ordinal][rowNum_];
-    }
+        public StubDbDataReader(Table table)
+        {
+            table_ = table;
+        }
 
-    public override long GetChars(int ordinal, long dataOffset, char[] buffer, int bufferOffset, int length)
-    {
-        throw new NotImplementedException();
-    }
+        public override bool GetBoolean(int ordinal)
+        {
+            return (int)table_[ordinal][rowNum_] != 0;
+        }
 
-    public override string GetDataTypeName(int ordinal)
-    {
-        return table[ordinal][rowNum_].GetType().Name;
-    }
+        public override byte GetByte(int ordinal)
+        {
+            return (byte)table_[ordinal][rowNum_];
+        }
 
-    public override DateTime GetDateTime(int ordinal)
-    {
-        return (DateTime)table[ordinal][rowNum_];
-    }
+        public override long GetBytes(int ordinal, long dataOffset, byte[] buffer, int bufferOffset, int length)
+        {
+            throw new NotImplementedException();
+        }
 
-    public override decimal GetDecimal(int ordinal)
-    {
-        return (decimal)table[ordinal][rowNum_];
-    }
+        public override char GetChar(int ordinal)
+        {
+            return (char)table_[ordinal][rowNum_];
+        }
 
-    public override double GetDouble(int ordinal)
-    {
-        return (double)table[ordinal][rowNum_];
-    }
+        public override long GetChars(int ordinal, long dataOffset, char[] buffer, int bufferOffset, int length)
+        {
+            throw new NotImplementedException();
+        }
 
-    public override IEnumerator GetEnumerator()
-    {
-        return table.Columns.Select(x => x[rowNum_]).GetEnumerator();
-    }
+        public override string GetDataTypeName(int ordinal)
+        {
+            return table_[ordinal][rowNum_].GetType().Name;
+        }
 
-    public override Type GetFieldType(int ordinal)
-    {
-        return table[ordinal][rowNum_].GetType();
-    }
+        public override DateTime GetDateTime(int ordinal)
+        {
+            return (DateTime)table_[ordinal][rowNum_];
+        }
 
-    public override float GetFloat(int ordinal)
-    {
-        return (float)table[ordinal][rowNum_];
-    }
+        public override decimal GetDecimal(int ordinal)
+        {
+            return (decimal)table_[ordinal][rowNum_];
+        }
 
-    public override Guid GetGuid(int ordinal)
-    {
-        return (Guid)table[ordinal][rowNum_];
-    }
+        public override double GetDouble(int ordinal)
+        {
+            return (double)table_[ordinal][rowNum_];
+        }
 
-    public override short GetInt16(int ordinal)
-    {
-        return (short)table[ordinal][rowNum_];
-    }
+        public override IEnumerator GetEnumerator()
+        {
+            return table_.Columns.Select(x => x[rowNum_]).GetEnumerator();
+        }
 
-    public override int GetInt32(int ordinal)
-    {
-        return (int)table[ordinal][rowNum_];
-    }
+        public override Type GetFieldType(int ordinal)
+        {
+            return table_[ordinal][rowNum_].GetType();
+        }
 
-    public override long GetInt64(int ordinal)
-    {
-        return (long)table[ordinal][rowNum_];
-    }
+        public override float GetFloat(int ordinal)
+        {
+            return (float)table_[ordinal][rowNum_];
+        }
 
-    public override string GetName(int ordinal)
-    {
-        return table[ordinal].Name;
-    }
+        public override Guid GetGuid(int ordinal)
+        {
+            return (Guid)table_[ordinal][rowNum_];
+        }
 
-    public override int GetOrdinal(string name)
-    {
-        return table.ColumnNames.IndexOf(name);
-    }
+        public override short GetInt16(int ordinal)
+        {
+            return (short)table_[ordinal][rowNum_];
+        }
 
-    public override string GetString(int ordinal)
-    {
-        return (string)table[ordinal][rowNum_];
-    }
+        public override int GetInt32(int ordinal)
+        {
+            return (int)table_[ordinal][rowNum_];
+        }
 
-    public override object GetValue(int ordinal)
-    {
-        return table[ordinal][rowNum_];
-    }
+        public override long GetInt64(int ordinal)
+        {
+            return (long)table_[ordinal][rowNum_];
+        }
 
-    public override int GetValues(object[] values)
-    {
-        var array = table.ColumnNames.Select(x => x[rowNum_]).ToArray();
-        array.CopyTo(values, 0);
-        return array.Length;
-    }
+        public override string GetName(int ordinal)
+        {
+            return table_[ordinal].Name;
+        }
 
-    public override bool IsDBNull(int ordinal)
-    {
-        return this[ordinal] is DBNull;
-    }
+        public override int GetOrdinal(string name)
+        {
+            return table_.ColumnNames.IndexOf(name);
+        }
 
-    public override bool NextResult()
-    {
-        throw new NotImplementedException();
-    }
+        public override string GetString(int ordinal)
+        {
+            return (string)table_[ordinal][rowNum_];
+        }
 
-    public override bool Read()
-    {
-        rowNum_++;
-        return 0 <= rowNum_ && rowNum_ < table.Columns[0].Values.Count;
+        public override object GetValue(int ordinal)
+        {
+            return table_[ordinal][rowNum_];
+        }
+
+        public override int GetValues(object[] values)
+        {
+            var array = table_.ColumnNames.Select(x => x[rowNum_]).ToArray();
+            array.CopyTo(values, 0);
+            return array.Length;
+        }
+
+        public override bool IsDBNull(int ordinal)
+        {
+            return this[ordinal] is DBNull;
+        }
+
+        public override bool NextResult()
+        {
+            throw new NotImplementedException();
+        }
+
+        public override bool Read()
+        {
+            rowNum_++;
+            return 0 <= rowNum_ && rowNum_ < table_.Columns[0].Values.Count;
+        }
     }
 }

--- a/LibDbHelper.Test/Stubs/StubDbHelper.cs
+++ b/LibDbHelper.Test/Stubs/StubDbHelper.cs
@@ -1,76 +1,87 @@
-﻿using System.Data.Common;
+﻿using LibDbHelper.Test.Items;
+using System;
+using System.Collections.Generic;
+using System.Data.Common;
+using System.Linq;
 using System.Text;
-using LibDbHelper.Test.Items;
+using System.Threading.Tasks;
 using Xunit.Abstractions;
 
-namespace LibDbHelper.Test.Stubs;
-
-public class StubDbHelper(ITestOutputHelper testOutputHelper) : DbHelper("")
+namespace LibDbHelper.Test.Stubs
 {
-    private Table table_;
-
-    protected override DbConnection GetConnection(string connectionString)
+    public class StubDbHelper : DbHelper
     {
-        return new StubDbConnection(table_);
-    }
+        private readonly ITestOutputHelper testOutputHelper_;
+        private Table table_;
 
-    protected override DbCommand GetCommand(string sql, DbConnection connection)
-    {
-        return new StubDbCommand(table_);
-    }
-
-    public override DbParameter GetParameter(string parameterName, object value)
-    {
-        return new StubDbParameter { ParameterName = parameterName, Value = value };
-    }
-
-    public override async Task BulkInsertAsync<T>(string table, IEnumerable<string> columns, IEnumerable<string> values, IEnumerable<T> entities, Func<string, T, object> getParameterValue, char placeHolderSymbol)
-    {
-        var sql = new StringBuilder();
-        sql.AppendLine("INSERT ALL");
-        var parameters = new List<DbParameter>();
-        for (var i = 0; i < entities.Count(); i++)
+        public StubDbHelper(ITestOutputHelper testOutputHelper) : base("")
         {
-            sql.Append($"INTO {table}");
-            if (columns.Any())
+            testOutputHelper_ = testOutputHelper;
+        }
+
+        protected override DbConnection GetConnection(string connectionString)
+        {
+            return new StubDbConnection(table_);
+        }
+
+        protected override DbCommand GetCommand(string sql, DbConnection connection)
+        {
+            return new StubDbCommand(table_);
+        }
+
+        public override DbParameter GetParameter(string parameterName, object value)
+        {
+            return new StubDbParameter { ParameterName = parameterName, Value = value };
+        }
+
+        public override async Task BulkInsertAsync<T>(string table, IEnumerable<string> columns, IEnumerable<string> values, IEnumerable<T> entities, Func<string, T, object> getParameterValue, char placeHolderSymbol)
+        {
+            var sql = new StringBuilder();
+            sql.AppendLine("INSERT ALL");
+            var parameters = new List<DbParameter>();
+            for (var i = 0; i < entities.Count(); i++)
             {
-                sql.AppendLine($" ({string.Join(",", columns)})");
-            }
-            else
-            {
-                sql.AppendLine();
-            }
-            var valuesModified = new List<string>();
-            foreach (var value in values)
-            {
-                // 先頭に{placeHolderSymbol}が付いていたらbind変数と判断する
-                // 連番を付与してパラメーターを作成する
-                if (value.StartsWith(placeHolderSymbol.ToString()))
+                sql.Append($"INTO {table}");
+                if (columns.Any())
                 {
-                    var name = value.TrimStart(placeHolderSymbol);
-                    valuesModified.Add($"{placeHolderSymbol}{name}{i}");
-                    parameters.Add(GetParameter($"{name}{i}", getParameterValue(name, entities.ElementAt(i))));
+                    sql.AppendLine($" ({string.Join(",", columns)})");
                 }
-                // 先頭に付いていなかったらリテラルと判断する
                 else
                 {
-                    valuesModified.Add(value);
+                    sql.AppendLine();
                 }
+                var valuesModified = new List<string>();
+                foreach (var value in values)
+                {
+                    // 先頭に{placeHolderSymbol}が付いていたらbind変数と判断する
+                    // 連番を付与してパラメーターを作成する
+                    if (value.StartsWith(placeHolderSymbol.ToString()))
+                    {
+                        var name = value.TrimStart(placeHolderSymbol);
+                        valuesModified.Add($"{placeHolderSymbol}{name}{i}");
+                        parameters.Add(GetParameter($"{name}{i}", getParameterValue(name, entities.ElementAt(i))));
+                    }
+                    // 先頭に付いていなかったらリテラルと判断する
+                    else
+                    {
+                        valuesModified.Add(value);
+                    }
+                }
+                sql.AppendLine($"VALUES ({string.Join(",", valuesModified)})");
             }
-            sql.AppendLine($"VALUES ({string.Join(",", valuesModified)})");
+            sql.Append("SELECT * FROM DUAL");
+            await ExecuteAsync(sql.ToString(), parameters);
+
+            // テスト用標出力
+            testOutputHelper_.WriteLine($"sql:");
+            testOutputHelper_.WriteLine(sql.ToString());
+            testOutputHelper_.WriteLine("parameters:");
+            testOutputHelper_.WriteLine(string.Join("\n", parameters.Select(x => x.ToString())));
         }
-        sql.Append("SELECT * FROM DUAL");
-        await ExecuteAsync(sql.ToString(), parameters);
 
-        // テスト用標出力
-        testOutputHelper.WriteLine($"sql:");
-        testOutputHelper.WriteLine(sql.ToString());
-        testOutputHelper.WriteLine("parameters:");
-        testOutputHelper.WriteLine(string.Join("\n", parameters.Select(x => x.ToString())));
-    }
-
-    public void SetTable(Table table)
-    {
-        table_ = table;
+        public void SetTable(Table table)
+        {
+            table_ = table;
+        }
     }
 }

--- a/LibDbHelper.Test/Stubs/StubDbParameter.cs
+++ b/LibDbHelper.Test/Stubs/StubDbParameter.cs
@@ -1,25 +1,26 @@
 ﻿using System.Data;
 using System.Data.Common;
 
-namespace LibDbHelper.Test.Stubs;
-
-public class StubDbParameter : DbParameter
+namespace LibDbHelper.Test.Stubs
 {
-    public override DbType DbType { get; set; }
-    public override ParameterDirection Direction { get; set; }
-    public override bool IsNullable { get; set; }
-    public override string ParameterName { get; set; }
-    public override int Size { get; set; }
-    public override string SourceColumn { get; set; }
-    public override bool SourceColumnNullMapping { get; set; }
-    public override object Value { get; set; }
-
-    public override void ResetDbType()
+    public class StubDbParameter : DbParameter
     {
-    }
+        public override DbType DbType { get; set; }
+        public override ParameterDirection Direction { get; set; }
+        public override bool IsNullable { get; set; }
+        public override string ParameterName { get; set; }
+        public override int Size { get; set; }
+        public override string SourceColumn { get; set; }
+        public override bool SourceColumnNullMapping { get; set; }
+        public override object Value { get; set; }
 
-    public override string ToString()
-    {
-        return $"Name:{ParameterName} Value:{Value}";
+        public override void ResetDbType()
+        {
+        }
+
+        public override string ToString()
+        {
+            return $"Name:{ParameterName} Value:{Value}";
+        }
     }
 }

--- a/LibDbHelper.Test/Stubs/StubDbParameterCollection.cs
+++ b/LibDbHelper.Test/Stubs/StubDbParameterCollection.cs
@@ -1,101 +1,105 @@
-﻿using System.Collections;
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
 using System.Data.Common;
+using System.Linq;
 
-namespace LibDbHelper.Test.Stubs;
-
-public class StubDbParameterCollection : DbParameterCollection
+namespace LibDbHelper.Test.Stubs
 {
-    private readonly List<StubDbParameter> parameters_ = [];
-
-    public override int Count => parameters_.Count;
-    public override object SyncRoot => ((IList)parameters_).SyncRoot;
-
-    public override int Add(object value)
+    public class StubDbParameterCollection : DbParameterCollection
     {
-        return ((IList)parameters_).Add(value);
-    }
+        private readonly List<StubDbParameter> parameters_ = new List<StubDbParameter>();
 
-    public override void AddRange(Array values)
-    {
-        foreach (var item in values)
+        public override int Count => parameters_.Count;
+        public override object SyncRoot => ((IList)parameters_).SyncRoot;
+
+        public override int Add(object value)
         {
-            Add(item);
+            return ((IList)parameters_).Add(value);
         }
-    }
 
-    public override void Clear()
-    {
-        parameters_.Clear();
-    }
+        public override void AddRange(Array values)
+        {
+            foreach (var item in values)
+            {
+                Add(item);
+            }
+        }
 
-    public override bool Contains(object value)
-    {
-        return parameters_.Select(x => x.Value).Contains(value);
-    }
+        public override void Clear()
+        {
+            parameters_.Clear();
+        }
 
-    public override bool Contains(string parameterName)
-    {
-        return parameters_.Select(x => x.ParameterName).Contains(parameterName);
-    }
+        public override bool Contains(object value)
+        {
+            return parameters_.Select(x => x.Value).Contains(value);
+        }
 
-    public override void CopyTo(Array array, int index)
-    {
-        ((IList)parameters_).CopyTo(array, index);
-    }
+        public override bool Contains(string parameterName)
+        {
+            return parameters_.Select(x => x.ParameterName).Contains(parameterName);
+        }
 
-    public override IEnumerator GetEnumerator()
-    {
-        return parameters_.GetEnumerator();
-    }
+        public override void CopyTo(Array array, int index)
+        {
+            ((IList)parameters_).CopyTo(array, index);
+        }
 
-    public override int IndexOf(object value)
-    {
-        return parameters_.Select(x => x.Value).ToList().IndexOf(value);
-    }
+        public override IEnumerator GetEnumerator()
+        {
+            return parameters_.GetEnumerator();
+        }
 
-    public override int IndexOf(string parameterName)
-    {
-        return parameters_.Select(x => x.ParameterName).ToList().IndexOf(parameterName);
-    }
+        public override int IndexOf(object value)
+        {
+            return parameters_.Select(x => x.Value).ToList().IndexOf(value);
+        }
 
-    public override void Insert(int index, object value)
-    {
-        ((IList)parameters_).Insert(index, value);
-    }
+        public override int IndexOf(string parameterName)
+        {
+            return parameters_.Select(x => x.ParameterName).ToList().IndexOf(parameterName);
+        }
 
-    public override void Remove(object value)
-    {
-        ((IList)parameters_).Remove(value);
-    }
+        public override void Insert(int index, object value)
+        {
+            ((IList)parameters_).Insert(index, value);
+        }
 
-    public override void RemoveAt(int index)
-    {
-        ((IList)parameters_).RemoveAt(index);
-    }
+        public override void Remove(object value)
+        {
+            ((IList)parameters_).Remove(value);
+        }
 
-    public override void RemoveAt(string parameterName)
-    {
-        parameters_.RemoveAt(IndexOf(parameterName));
-    }
+        public override void RemoveAt(int index)
+        {
+            ((IList)parameters_).RemoveAt(index);
+        }
 
-    protected override DbParameter GetParameter(int index)
-    {
-        return parameters_[index];
-    }
+        public override void RemoveAt(string parameterName)
+        {
+            parameters_.RemoveAt(IndexOf(parameterName));
+        }
 
-    protected override DbParameter GetParameter(string parameterName)
-    {
-        return parameters_.First(x => x.ParameterName == parameterName);
-    }
+        protected override DbParameter GetParameter(int index)
+        {
+            return parameters_[index];
+        }
 
-    protected override void SetParameter(int index, DbParameter value)
-    {
-        parameters_[index] = (StubDbParameter)value;
-    }
+        protected override DbParameter GetParameter(string parameterName)
+        {
+            return parameters_.First(x => x.ParameterName == parameterName);
+        }
 
-    protected override void SetParameter(string parameterName, DbParameter value)
-    {
-        var index = IndexOf(parameterName);
-        parameters_[index] = (StubDbParameter)value;
+        protected override void SetParameter(int index, DbParameter value)
+        {
+            parameters_[index] = (StubDbParameter)value;
+        }
+
+        protected override void SetParameter(string parameterName, DbParameter value)
+        {
+            var index = IndexOf(parameterName);
+            parameters_[index] = (StubDbParameter)value;
+        }
     }
 }

--- a/LibDbHelper.Test/Stubs/StubDbTransaction.cs
+++ b/LibDbHelper.Test/Stubs/StubDbTransaction.cs
@@ -1,18 +1,25 @@
 ﻿using System.Data;
 using System.Data.Common;
 
-namespace LibDbHelper.Test.Stubs;
-
-public class StubDbTransaction(StubDbConnection connection, IsolationLevel isolationLevel) : DbTransaction
+namespace LibDbHelper.Test.Stubs
 {
-    protected override DbConnection DbConnection { get; } = connection;
-    public override IsolationLevel IsolationLevel { get; } = isolationLevel;
-
-    public override void Commit()
+    public class StubDbTransaction : DbTransaction
     {
-    }
+        protected override DbConnection DbConnection { get; }
+        public override IsolationLevel IsolationLevel { get; }
 
-    public override void Rollback()
-    {
+        public StubDbTransaction(DbConnection dbConnection, IsolationLevel isolationLevel)
+        {
+            DbConnection = dbConnection;
+            IsolationLevel = isolationLevel;
+        }
+
+        public override void Commit()
+        {
+        }
+
+        public override void Rollback()
+        {
+        }
     }
 }


### PR DESCRIPTION
- プロジェクトのプロパティからLangVersionとImplicitUsingsを削除
- xUnitのGlobalUsingも削除